### PR TITLE
Fix missing MITM stop function

### DIFF
--- a/mek-security.sh
+++ b/mek-security.sh
@@ -331,6 +331,16 @@ start_mitm_monitoring() {
     fi
 }
 
+stop_mitm_monitoring() {
+    kill "$mitm_pid" 2>/dev/null; mitm_pid=""
+    [[ -n "$attacker_monitor_pid" ]] && kill "$attacker_monitor_pid" 2>/dev/null; attacker_monitor_pid=""
+    if [[ "$lang" == "tr" ]]; then
+        echo -e "${RED}MITM izleme durduruldu.${RESET}"
+    else
+        echo -e "${RED}MITM monitoring stopped.${RESET}"
+    fi
+}
+
 start_packet_tracking() {
     tracking_loop &
     tracking_pid=$!
@@ -346,11 +356,11 @@ fi
 stop_packet_tracking() {
     kill "$tracking_pid" 2>/dev/null; tracking_pid=""
     [[ -n "$attacker_monitor_pid" ]] && kill "$attacker_monitor_pid" 2>/dev/null; attacker_monitor_pid=""
-if [[ "$lang" == "tr" ]]; then
-    echo -e "${RED}MITM izleme durduruldu.${RESET}"
-else
-    echo -e "${RED}MITM monitoring stopped.${RESET}"
-fi
+    if [[ "$lang" == "tr" ]]; then
+        echo -e "${RED}Paket izleme durduruldu.${RESET}"
+    else
+        echo -e "${RED}Packet tracking stopped.${RESET}"
+    fi
 }
 
 mitm_loop() {


### PR DESCRIPTION
## Summary
- add missing `stop_mitm_monitoring` to shut down MITM processes
- correct message in `stop_packet_tracking`

## Testing
- `bash -n mek-security.sh`
- `shellcheck mek-security.sh 2>&1 | head` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ab4b10a84832e8b79c3d12a9deb7b